### PR TITLE
Add GitHub Actions workflow for deploying to GitHub Pages

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,30 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Configure GitHub Pages
+        uses: actions/configure-pages@v3
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v2
+        with:
+          path: '.' # Assuming the entire repository is the site
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v2


### PR DESCRIPTION
This pull request adds a new GitHub Actions workflow to automate deployment to GitHub Pages. The workflow is triggered on pushes to the `main` branch and includes steps for repository checkout, configuration, artifact upload, and deployment.

Deployment automation:

* [`.github/workflows/deploy.yml`](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3R1-R30): Created a new workflow named "Deploy to GitHub Pages" that is triggered on pushes to the `main` branch. It grants necessary permissions and defines steps to checkout the repository, configure GitHub Pages, upload artifacts, and deploy the site using GitHub Actions.